### PR TITLE
Fixed wrong Icon when setting expanded to true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ const defaultProps = {
 
 class Accordion extends Component {
   state = {
-    is_visible: false,
+    is_visible: false || this.props.expanded,
     height: new Animated.Value(0),
     content_height: 0
   };


### PR DESCRIPTION
When setting `expanded` true, the wrong Icon would be rendered. This resolved the issue for me.